### PR TITLE
Disabing asset deletion due to problems with FairPlay encryption.

### DIFF
--- a/AMSExplorer.sln
+++ b/AMSExplorer.sln
@@ -5,11 +5,6 @@ VisualStudioVersion = 14.0.25420.1
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "AMSExplorer", "AMSExplorer\AMSExplorer.csproj", "{67573AA5-0316-4C90-8CE4-93A950CD0A86}"
 EndProject
-Project("{6141683F-8A12-4E36-9623-2EB02B2C2303}") = "SetupAMSExplorer", "SetupAMSExplorer\SetupAMSExplorer.isproj", "{FEC674B1-FBE6-4D9B-8F5E-7AE13F881F37}"
-	ProjectSection(ProjectDependencies) = postProject
-		{67573AA5-0316-4C90-8CE4-93A950CD0A86} = {67573AA5-0316-4C90-8CE4-93A950CD0A86}
-	EndProjectSection
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		CD_ROM|Any CPU = CD_ROM|Any CPU
@@ -29,16 +24,6 @@ Global
 		{67573AA5-0316-4C90-8CE4-93A950CD0A86}.Release|Any CPU.Build.0 = Release|Any CPU
 		{67573AA5-0316-4C90-8CE4-93A950CD0A86}.SingleImage|Any CPU.ActiveCfg = Release|Any CPU
 		{67573AA5-0316-4C90-8CE4-93A950CD0A86}.SingleImage|Any CPU.Build.0 = Release|Any CPU
-		{FEC674B1-FBE6-4D9B-8F5E-7AE13F881F37}.CD_ROM|Any CPU.ActiveCfg = CD_ROM
-		{FEC674B1-FBE6-4D9B-8F5E-7AE13F881F37}.CD_ROM|Any CPU.Build.0 = CD_ROM
-		{FEC674B1-FBE6-4D9B-8F5E-7AE13F881F37}.Debug|Any CPU.ActiveCfg = SingleImage
-		{FEC674B1-FBE6-4D9B-8F5E-7AE13F881F37}.Debug|Any CPU.Build.0 = SingleImage
-		{FEC674B1-FBE6-4D9B-8F5E-7AE13F881F37}.DVD-5|Any CPU.ActiveCfg = DVD-5
-		{FEC674B1-FBE6-4D9B-8F5E-7AE13F881F37}.DVD-5|Any CPU.Build.0 = DVD-5
-		{FEC674B1-FBE6-4D9B-8F5E-7AE13F881F37}.Release|Any CPU.ActiveCfg = SingleImage
-		{FEC674B1-FBE6-4D9B-8F5E-7AE13F881F37}.Release|Any CPU.Build.0 = SingleImage
-		{FEC674B1-FBE6-4D9B-8F5E-7AE13F881F37}.SingleImage|Any CPU.ActiveCfg = SingleImage
-		{FEC674B1-FBE6-4D9B-8F5E-7AE13F881F37}.SingleImage|Any CPU.Build.0 = SingleImage
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/AMSExplorer/AMSExplorer.csproj
+++ b/AMSExplorer/AMSExplorer.csproj
@@ -91,8 +91,8 @@
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.Practices.TransientFaultHandling.Core, Version=5.1.1209.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\TransientFaultHandling.Core.5.1.1209.1\lib\NET4\Microsoft.Practices.TransientFaultHandling.Core.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.WindowsAPICodePack, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Windows7APICodePack-Core.1.1.0.0\lib\Microsoft.WindowsAPICodePack.dll</HintPath>
@@ -126,8 +126,8 @@
       <HintPath>..\packages\windowsazure.mediaservices.extensions.4.0.0.4\lib\net45\Microsoft.WindowsAzure.MediaServices.Client.Extensions.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Microsoft.WindowsAzure.Storage, Version=8.1.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\WindowsAzure.Storage.8.1.4\lib\net45\Microsoft.WindowsAzure.Storage.dll</HintPath>
+    <Reference Include="Microsoft.WindowsAzure.Storage, Version=7.2.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\WindowsAzure.Storage.7.2.1\lib\net40\Microsoft.WindowsAzure.Storage.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
@@ -867,6 +867,7 @@
     <Content Include="MESPresetFiles\Content Adaptive Multiple Bitrate MP4.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
+    <None Include="packages.config" />
     <None Include="Resources\media-services-dvr-filter.png" />
     <None Include="Resources\media-services-livebackoff-filter.png" />
     <None Include="Resources\media-services-multiple-rules-filters.png" />
@@ -1459,9 +1460,6 @@
     <Content Include="License\Azure Media Services Explorer.rtf">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
-    <None Include="packages.config">
-      <SubType>Designer</SubType>
-    </None>
     <None Include="Properties\Settings.settings">
       <Generator>SettingsSingleFileGenerator</Generator>
       <LastGenOutput>Settings.Designer.cs</LastGenOutput>

--- a/AMSExplorer/App.config
+++ b/AMSExplorer/App.config
@@ -40,7 +40,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.WindowsAzure.Storage" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.1.4.0" newVersion="8.1.4.0" />
+        <bindingRedirect oldVersion="0.0.0.0-7.2.1.0" newVersion="7.2.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Protocol.Extensions" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/AMSExplorer/Mainform.Designer.cs
+++ b/AMSExplorer/Mainform.Designer.cs
@@ -2861,7 +2861,6 @@
             this.assetToolStripMenuItem.Name = "assetToolStripMenuItem";
             resources.ApplyResources(this.assetToolStripMenuItem, "assetToolStripMenuItem");
             this.assetToolStripMenuItem.DropDownOpening += new System.EventHandler(this.toolStripMenuAsset_DropDownOpening);
-            this.assetToolStripMenuItem.Click += new System.EventHandler(this.assetToolStripMenuItem_Click);
             // 
             // informationToolStripMenuItem
             // 

--- a/AMSExplorer/Mainform.cs
+++ b/AMSExplorer/Mainform.cs
@@ -2475,14 +2475,7 @@ namespace AMSExplorer
                 }
             }
         }
-
-        private void assetToolStripMenuItem_Click(object sender, EventArgs e)
-        {
-
-        }
-
-
-
+        
         private void DoCreateLocator(List<IAsset> SelectedAssets)
         {
             string labelAssetName;
@@ -7041,6 +7034,9 @@ namespace AMSExplorer
             createAnAssetFilterToolStripMenuItem.Enabled =
             displayParentJobToolStripMenuItem1.Enabled = singleitem;
 
+            //TODO: due to heavy problems with asset with fairplay encryption this option is unavaliable now
+            ContextMenuItemAssetDelete.Enabled = false;
+
             if (singleitem && firstAsset != null && firstAsset.AssetFiles.Count() == 1)
             {
                 var assetfile = firstAsset.AssetFiles.FirstOrDefault();
@@ -7075,6 +7071,9 @@ namespace AMSExplorer
             editAlternateIdToolStripMenuItem1.Enabled =
             toAzureStorageToolStripMenuItem.Enabled =
             displayParentJobToolStripMenuItem.Enabled = singleitem;
+
+            //TODO: due to heavy problems with asset with fairplay encryption this option is unavaliable now
+            this.deleteToolStripMenuItem.Enabled = false;
 
             if (singleitem && (assets.FirstOrDefault().AssetFiles.Count() == 1))
             {
@@ -15883,7 +15882,7 @@ namespace AMSExplorer
         private void linkLabelMoreInfoMediaUnits_LinkClicked(object sender, LinkLabelLinkClickedEventArgs e)
         {
             Process.Start(e.Link.LinkData as string);
-        }
+        }        
     }
 }
 

--- a/AMSExplorer/Mainform.resx
+++ b/AMSExplorer/Mainform.resx
@@ -1140,7 +1140,7 @@
     <value>dataGridViewAssetsV</value>
   </data>
   <data name="&gt;&gt;dataGridViewAssetsV.Type" xml:space="preserve">
-    <value>AMSExplorer.DataGridViewAssets, AMSExplorer, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>AMSExplorer.DataGridViewAssets, AMSExplorer, Version=4.0.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;dataGridViewAssetsV.Parent" xml:space="preserve">
     <value>tabPageAssets</value>
@@ -1697,7 +1697,7 @@
     <value>dataGridViewIngestManifestsV</value>
   </data>
   <data name="&gt;&gt;dataGridViewIngestManifestsV.Type" xml:space="preserve">
-    <value>AMSExplorer.DataGridViewIngestManifest, AMSExplorer, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>AMSExplorer.DataGridViewIngestManifest, AMSExplorer, Version=4.0.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;dataGridViewIngestManifestsV.Parent" xml:space="preserve">
     <value>tabPageTransfers</value>
@@ -2583,7 +2583,7 @@
     <value>dataGridViewJobsV</value>
   </data>
   <data name="&gt;&gt;dataGridViewJobsV.Type" xml:space="preserve">
-    <value>AMSExplorer.DataGridViewJobs, AMSExplorer, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>AMSExplorer.DataGridViewJobs, AMSExplorer, Version=4.0.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;dataGridViewJobsV.Parent" xml:space="preserve">
     <value>tabPageJobs</value>
@@ -2899,7 +2899,7 @@
     <value>dataGridViewProgramsV</value>
   </data>
   <data name="&gt;&gt;dataGridViewProgramsV.Type" xml:space="preserve">
-    <value>AMSExplorer.DataGridViewLiveProgram, AMSExplorer, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>AMSExplorer.DataGridViewLiveProgram, AMSExplorer, Version=4.0.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;dataGridViewProgramsV.Parent" xml:space="preserve">
     <value>panelPrograms</value>
@@ -3546,7 +3546,7 @@
     <value>dataGridViewChannelsV</value>
   </data>
   <data name="&gt;&gt;dataGridViewChannelsV.Type" xml:space="preserve">
-    <value>AMSExplorer.DataGridViewLiveChannel, AMSExplorer, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>AMSExplorer.DataGridViewLiveChannel, AMSExplorer, Version=4.0.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;dataGridViewChannelsV.Parent" xml:space="preserve">
     <value>panelChannels</value>
@@ -4068,7 +4068,7 @@
     <value>dataGridViewStreamingEndpointsV</value>
   </data>
   <data name="&gt;&gt;dataGridViewStreamingEndpointsV.Type" xml:space="preserve">
-    <value>AMSExplorer.DataGridViewStreamingEndpoints, AMSExplorer, Version=4.0.0.0, Culture=neutral, PublicKeyToken=null</value>
+    <value>AMSExplorer.DataGridViewStreamingEndpoints, AMSExplorer, Version=4.0.1.0, Culture=neutral, PublicKeyToken=null</value>
   </data>
   <data name="&gt;&gt;dataGridViewStreamingEndpointsV.Parent" xml:space="preserve">
     <value>tabPageOrigins</value>
@@ -8950,7 +8950,7 @@
     <value>True</value>
   </metadata>
   <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-    <value>112</value>
+    <value>275</value>
   </metadata>
   <data name="$this.AutoScaleDimensions" type="System.Drawing.SizeF, System.Drawing">
     <value>6, 13</value>

--- a/AMSExplorer/packages.config
+++ b/AMSExplorer/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.Azure.KeyVault.Core" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.Data.Edm" version="5.8.2" targetFramework="net46" />
   <package id="Microsoft.Data.OData" version="5.8.2" targetFramework="net46" />
   <package id="Microsoft.Data.Services.Client" version="5.8.2" targetFramework="net46" />
@@ -14,7 +14,7 @@
   <package id="System.Linq.Queryable" version="4.0.0" targetFramework="net46" />
   <package id="System.Net.Requests" version="4.0.11" targetFramework="net46" />
   <package id="System.Spatial" version="5.8.2" targetFramework="net46" />
-  <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net45" />
+  <package id="TransientFaultHandling.Core" version="5.1.1209.1" targetFramework="net46" />
   <package id="Windows7APICodePack-Core" version="1.1.0.0" targetFramework="net46" />
   <package id="Windows7APICodePack-Shell" version="1.1.0.0" targetFramework="net46" />
   <package id="windowsazure.mediaservices" version="4.0.0.4" targetFramework="net46" />


### PR DESCRIPTION
Disabling option to delete an asset will avoid problems with FairPlay encryption problems.