### PR TITLE
CopytoAnotherAMS: Copy Asset's AlternateId

### DIFF
--- a/AMSExplorer/Mainform.cs
+++ b/AMSExplorer/Mainform.cs
@@ -3653,6 +3653,9 @@ namespace AMSExplorer
             try
             {
                 TargetAsset = DestinationContext.Assets.Create(TargetAssetName, DestinationStorageAccount, AssetCreationOptions.None);
+
+                TargetAsset.AlternateId = SourceAssets.FirstOrDefault().AlternateId;
+                TargetAsset.Update();
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
When custom AlternateIds are being used, copying these video assets this AlternateId information is lost. This is a problem for scenarios where AlternateIds are relied upon by custom applications.