### PR TITLE
Correct height for preset "H264 Multiple Bitrate 16x9 for iOS"

### DIFF
--- a/AMSExplorer/MESPresetFiles/H264 Multiple Bitrate 16x9 for iOS.json
+++ b/AMSExplorer/MESPresetFiles/H264 Multiple Bitrate 16x9 for iOS.json
@@ -106,7 +106,7 @@
           "MaxBitrate": 200,
           "BufferWindow": "00:00:05",
           "Width": 416,
-          "Height": 214,
+          "Height": 234,
           "ReferenceFrames": 3,
           "EntropyMode": "Cavlc",
           "Type": "H264Layer",


### PR DESCRIPTION
I think the encoder preset for "H264 Multiple Bitrate 16x9 for iOS" is wrong for the 200 Kbps entry.

For square pixels, a 16:9 aspect ratio, and a width of 416, the height should be 234, rather than the 214 in this profile.

With the default StretchMode of "AutoSize", this causes the encoder to theoretically want a file with height 380 + (4/9) pixels, and actually produces a file of 380x214. The display aspect ratio in the video file metadata is still 16:9, but could still result in slightly distorted playback given that 380:214 is not exactly 16:9.

The documentation for this preset will also need to be updated (https://docs.microsoft.com/en-us/azure/media-services/previous/media-services-mes-preset-h264-multiple-bitrate-16x9-for-ios).