### PR TITLE
Japanese correction for AMS v3

### DIFF
--- a/AMSExplorer/DeleteKeyAndPolicy.ja.resx
+++ b/AMSExplorer/DeleteKeyAndPolicy.ja.resx
@@ -118,16 +118,16 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="$this.Text" xml:space="preserve">
-    <value>プログラムの削除</value>
+    <value>ライブ出力の削除</value>
   </data>
   <data name="buttonCancel.Text" xml:space="preserve">
     <value>キャンセル</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>プログラムの削除</value>
+    <value>ライブ出力の削除</value>
   </data>
   <data name="buttonOk.Text" xml:space="preserve">
-    <value>プログラムの削除</value>
+    <value>ライブ出力の削除</value>
   </data>
   <data name="checkBoxDeleteAsset.Text" xml:space="preserve">
     <value>関連するアセットの削除</value>

--- a/AMSExplorer/DeleteLiveOutputEvent.ja.resx
+++ b/AMSExplorer/DeleteLiveOutputEvent.ja.resx
@@ -118,16 +118,16 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="$this.Text" xml:space="preserve">
-    <value>プログラムの削除</value>
+    <value>ライブ出力の削除</value>
   </data>
   <data name="buttonCancel.Text" xml:space="preserve">
     <value>キャンセル</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
-    <value>プログラムの削除</value>
+    <value>ライブ出力の削除</value>
   </data>
   <data name="buttonOk.Text" xml:space="preserve">
-    <value>プログラムの削除</value>
+    <value>ライブ出力の削除</value>
   </data>
   <data name="checkBoxDeleteAsset.Text" xml:space="preserve">
     <value>関連するアセットの削除</value>

--- a/AMSExplorer/Live/LiveEventCreation.ja.resx
+++ b/AMSExplorer/Live/LiveEventCreation.ja.resx
@@ -936,7 +936,7 @@
     <value />
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>ライブチャネルの作成</value>
+    <value>ライブイベントの作成</value>
   </data>
   <data name="$this.ToolTip" xml:space="preserve">
     <value />
@@ -966,13 +966,13 @@
     <value>キャンセル</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
-    <value>チャネル名: </value>
+    <value>ライブイベント名: </value>
   </data>
   <data name="TabSettings.Text" xml:space="preserve">
-    <value>チャネル設定 </value>
+    <value>ライブイベント設定 </value>
   </data>
   <data name="buttonOk.Text" xml:space="preserve">
-    <value>チャネルの作成</value>
+    <value>ライブイベントの作成</value>
   </data>
   <data name="buttonDelAddOption.Text" xml:space="preserve">
     <value>削除</value>
@@ -1017,7 +1017,7 @@
     <value>オーディオ ストリーム インデックス :</value>
   </data>
   <data name="labelWarning.Text" xml:space="preserve">
-    <value>実行中の状態のチャネルは費用がかかります</value>
+    <value>実行中の状態のライブイベントは費用がかかります</value>
   </data>
   <data name="label1.Text" xml:space="preserve">
     <value>広告マーカーのソース :</value>
@@ -1056,7 +1056,7 @@
     <value>ライブ エンコーディング (Azure Media Services) :</value>
   </data>
   <data name="checkBoxStartChannel.Text" xml:space="preserve">
-    <value>新しいチャネルをすぐに開始する</value>
+    <value>新しいライブイベントをすぐに開始する</value>
   </data>
   <data name="label14.Text" xml:space="preserve">
     <value>名前 または ID で検索 :</value>

--- a/AMSExplorer/Live/LiveEventInformation.ja.resx
+++ b/AMSExplorer/Live/LiveEventInformation.ja.resx
@@ -702,7 +702,7 @@
     <value>0</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>チャネル情報</value>
+    <value>ライブイベント情報</value>
   </data>
   <data name="contextMenuStripDG.Error" xml:space="preserve">
     <value />
@@ -741,10 +741,10 @@
     <value>追加</value>
   </data>
   <data name="labelChannelName.Text" xml:space="preserve">
-    <value>チャネル: </value>
+    <value>ライブイベント: </value>
   </data>
   <data name="tabPageChannelInfo.Text" xml:space="preserve">
-    <value>チャネル情報</value>
+    <value>ライブイベント情報</value>
   </data>
   <data name="buttonClose.Text" xml:space="preserve">
     <value>閉じる</value>
@@ -840,7 +840,7 @@
     <value>既定のオーディオ ストリーム</value>
   </data>
   <data name="labelChannelStoppedOrStartedSettings.Text" xml:space="preserve">
-    <value>設定を更新する場合は、チャネルは停止状態か実行状態である必要があります</value>
+    <value>設定を更新する場合は、ライブイベントは停止状態か実行状態である必要があります</value>
   </data>
   <data name="labelChannelStoppedOrStartedSettings.Location" type="System.Drawing.Point, System.Drawing">
     <value>148, 18</value>
@@ -849,10 +849,10 @@
     <value>416, 19</value>
   </data>
   <data name="labelIndexesChannelMustBeStopped.Text" xml:space="preserve">
-    <value>エンコーディング設定を変更する場合は、チャネルは停止状態である必要があります</value>
+    <value>エンコーディング設定を変更する場合は、ライブイベントは停止状態である必要があります</value>
   </data>
   <data name="labelChannelMustBeStopped.Text" xml:space="preserve">
-    <value>エンコーディング設定を変更する場合は、チャネルは停止状態である必要があります</value>
+    <value>エンコーディング設定を変更する場合は、ライブイベントは停止状態である必要があります</value>
   </data>
   <data name="checkBoxInputSet.Text" xml:space="preserve">
     <value>入力映像のアクセス許可 IP アドレスの設定 :</value>

--- a/AMSExplorer/Live/LiveOutputCreation.ja.resx
+++ b/AMSExplorer/Live/LiveOutputCreation.ja.resx
@@ -243,7 +243,7 @@
     <value>ライブ出力名 :</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>チャネル {0} の新しいライブ出力の作成</value>
+    <value>ライブイベント {0} の新しいライブ出力の作成</value>
   </data>
   <data name="buttonOk.Text" xml:space="preserve">
     <value>ライブ出力の作成</value>

--- a/AMSExplorer/Live/LiveOutputCreation.ja.resx
+++ b/AMSExplorer/Live/LiveOutputCreation.ja.resx
@@ -125,7 +125,7 @@
     <value>161, 19</value>
   </data>
   <data name="checkBoxStartProgramNow.Text" xml:space="preserve">
-    <value>プログラムをすぐに開始する</value>
+    <value>ライブ出力をすぐに開始する</value>
   </data>
   <data name="checkBoxDynEnc.Size" type="System.Drawing.Size, System.Drawing">
     <value>141, 19</value>
@@ -221,14 +221,14 @@
     <value>1ストリーミングユニットを追加する</value>
   </data>
   <data name="label5.Text" xml:space="preserve">
-    <value>ライブプログラムは、プログラムを停止した際に録画しているオンデマンドコンテンツに自動的に変換し、アセットタブからアクセスできます
-公開するすべてのストリーミングURLは、ライブプログラムが終了後も、そのまま利用可能となります</value>
+    <value>ライブ出力は、ライブ出力を停止した際に録画しているオンデマンドコンテンツに自動的に変換し、アセットタブからアクセスできます
+公開するすべてのストリーミングURLは、ライブ出力が終了後も、そのまま利用可能となります</value>
   </data>
   <data name="checkBoxCreateLocator.Size" type="System.Drawing.Size, System.Drawing">
     <value>398, 19</value>
   </data>
   <data name="checkBoxCreateLocator.Text" xml:space="preserve">
-    <value>このプログラム(アセット)をすぐに公開する (既定のロケーターの期間: {0} 日)</value>
+    <value>このライブ出力(アセット)をすぐに公開する (既定のロケーターの期間: {0} 日)</value>
   </data>
   <data name="label1.Size" type="System.Drawing.Size, System.Drawing">
     <value>39, 15</value>
@@ -240,24 +240,24 @@
     <value>75, 15</value>
   </data>
   <data name="label3.Text" xml:space="preserve">
-    <value>プログラム名 :</value>
+    <value>ライブ出力名 :</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>チャネル {0} の新しいプログラムの作成</value>
+    <value>チャネル {0} の新しいライブ出力の作成</value>
   </data>
   <data name="buttonOk.Text" xml:space="preserve">
-    <value>プログラムの作成</value>
+    <value>ライブ出力の作成</value>
   </data>
   <data name="labelCloneLocators.Text" xml:space="preserve">
     <value>(自動生成の場合は空欄のまま)</value>
   </data>
   <data name="label6.Text" xml:space="preserve">
-    <value>レプリカ (複製プログラム) の出力 URL:</value>
+    <value>レプリカ (複製ライブ出力) の出力 URL:</value>
   </data>
   <data name="checkBoxReplica.Text" xml:space="preserve">
-    <value>このプログラムはもう1つのデータセンターにあるプログラムのレプリカである</value>
+    <value>このライブ出力はもう1つのデータセンターにあるライブ出力のレプリカである</value>
   </data>
   <data name="label8.Text" xml:space="preserve">
-    <value>このオプションは、もう1つのデータセンターにあるライブプログラムを作成し、同じ URL パスで新しいプログラムを生成したい場合に、利用します</value>
+    <value>このオプションは、もう1つのデータセンターにあるライブ出力を作成し、同じ URL パスで新しいライブ出力を生成したい場合に、利用します</value>
   </data>
 </root>

--- a/AMSExplorer/Live/LiveOutputInformation.ja.resx
+++ b/AMSExplorer/Live/LiveOutputInformation.ja.resx
@@ -128,7 +128,7 @@
     <value>172, 26</value>
   </data>
   <data name="tabPageInfo.Text" xml:space="preserve">
-    <value>プログラム情報</value>
+    <value>ライブ出力情報</value>
   </data>
   <data name="buttonDisplayRelatedAsset.Text" xml:space="preserve">
     <value>関連するアセット情報の表示</value>
@@ -170,7 +170,7 @@
     <value>設定</value>
   </data>
   <data name="labelProgramName.Text" xml:space="preserve">
-    <value>プログラム :</value>
+    <value>ライブ出力 :</value>
   </data>
   <data name="buttonClose.Text" xml:space="preserve">
     <value>閉じる</value>
@@ -179,6 +179,6 @@
     <value>設定を更新して閉じる</value>
   </data>
   <data name="$this.Text" xml:space="preserve">
-    <value>プログラム情報</value>
+    <value>ライブ出力情報</value>
   </data>
 </root>

--- a/AMSExplorer/Mainform.ja.resx
+++ b/AMSExplorer/Mainform.ja.resx
@@ -1592,7 +1592,7 @@
     <value>54, 15</value>
   </data>
   <data name="label14.Text" xml:space="preserve">
-    <value>チャネル: </value>
+    <value>ライブイベント: </value>
   </data>
   <data name="label14.ToolTip" xml:space="preserve">
     <value />
@@ -1668,7 +1668,7 @@
     <value>288, 22</value>
   </data>
   <data name="ContextMenuItemChannelDisplayInfomation.Text" xml:space="preserve">
-    <value>チャネルの情報表示と更新...</value>
+    <value>ライブイベントの情報表示と更新...</value>
   </data>
   <data name="loadMetricsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>288, 22</value>
@@ -1680,7 +1680,7 @@
     <value>288, 22</value>
   </data>
   <data name="ContextMenuItemChannelAdAndSlateControl.Text" xml:space="preserve">
-    <value>チャネルの広告とスレートの制御...</value>
+    <value>ライブイベントの広告とスレートの制御...</value>
   </data>
   <data name="createChannelToolStripMenuItem1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -1693,7 +1693,7 @@
     <value>288, 22</value>
   </data>
   <data name="createChannelToolStripMenuItem1.Text" xml:space="preserve">
-    <value>チャネルの作成...</value>
+    <value>ライブイベントの作成...</value>
   </data>
   <data name="ContextMenuItemChannelStart.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -1709,7 +1709,7 @@
     <value>288, 22</value>
   </data>
   <data name="ContextMenuItemChannelStart.Text" xml:space="preserve">
-    <value>チャネルの開始</value>
+    <value>ライブイベントの開始</value>
   </data>
   <data name="ContextMenuItemChannelStop.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -1722,7 +1722,7 @@
     <value>288, 22</value>
   </data>
   <data name="ContextMenuItemChannelStop.Text" xml:space="preserve">
-    <value>チャネルの停止</value>
+    <value>ライブイベントの停止</value>
   </data>
   <data name="ContextMenuItemChannelReset.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -1738,13 +1738,13 @@
     <value>288, 22</value>
   </data>
   <data name="ContextMenuItemChannelReset.Text" xml:space="preserve">
-    <value>チャネルのリセット</value>
+    <value>ライブイベントのリセット</value>
   </data>
   <data name="cloneChannelsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>288, 22</value>
   </data>
   <data name="cloneChannelsToolStripMenuItem.Text" xml:space="preserve">
-    <value>他のアカウントのチャネルの複製...</value>
+    <value>他のアカウントのライブイベントの複製...</value>
   </data>
   <data name="ContextMenuItemChannelDelete.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -1758,7 +1758,7 @@
     <value>288, 22</value>
   </data>
   <data name="ContextMenuItemChannelDelete.Text" xml:space="preserve">
-    <value>チャネルの削除...</value>
+    <value>ライブイベントの削除...</value>
   </data>
   <data name="toolStripSeparator14.Size" type="System.Drawing.Size, System.Drawing">
     <value>285, 6</value>
@@ -1843,7 +1843,7 @@
     <value>52, 13</value>
   </data>
   <data name="labelChannels.Text" xml:space="preserve">
-    <value>チャネル</value>
+    <value>ライブイベント</value>
   </data>
   <data name="labelChannels.ToolTip" xml:space="preserve">
     <value />
@@ -1852,7 +1852,7 @@
     <value />
   </data>
   <data name="textBoxSearchNameChannel.ToolTip" xml:space="preserve">
-    <value>チャネル名/チャネル ID で検索</value>
+    <value>ライブイベント名/ライブイベント ID で検索</value>
   </data>
   <data name="buttonSetFilterChannel.Text" xml:space="preserve">
     <value>適用</value>
@@ -1894,7 +1894,7 @@
     <value />
   </data>
   <data name="tabPageLive.Text" xml:space="preserve">
-    <value>ライブチャネル</value>
+    <value>ライブイベント</value>
   </data>
   <data name="tabPageLive.ToolTip" xml:space="preserve">
     <value />
@@ -3125,7 +3125,7 @@
     <value>288, 22</value>
   </data>
   <data name="channInfoToolStripMenuItem.Text" xml:space="preserve">
-    <value>チャネルの情報表示と設定...</value>
+    <value>ライブイベントの情報表示と設定...</value>
   </data>
   <data name="telemetryToolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
     <value>288, 22</value>
@@ -3137,7 +3137,7 @@
     <value>288, 22</value>
   </data>
   <data name="channelsAdAndSlateControlToolStripMenuItem.Text" xml:space="preserve">
-    <value>チャネルの広告とスレートの制御...</value>
+    <value>ライブイベントの広告とスレートの制御...</value>
   </data>
   <data name="createChannelToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -3150,7 +3150,7 @@
     <value>288, 22</value>
   </data>
   <data name="createChannelToolStripMenuItem.Text" xml:space="preserve">
-    <value>チャネルの作成...</value>
+    <value>ライブイベントの作成...</value>
   </data>
   <data name="startChannelsToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -3166,13 +3166,13 @@
     <value>288, 22</value>
   </data>
   <data name="startChannelsToolStripMenuItem.Text" xml:space="preserve">
-    <value>チャネルの開始</value>
+    <value>ライブイベントの開始</value>
   </data>
   <data name="toolStripMenuItemCloneChannel.Size" type="System.Drawing.Size, System.Drawing">
     <value>288, 22</value>
   </data>
   <data name="toolStripMenuItemCloneChannel.Text" xml:space="preserve">
-    <value>他のアカウントのチャネルの複製...</value>
+    <value>他のアカウントのライブイベントの複製...</value>
   </data>
   <data name="stopChannelsToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -3185,7 +3185,7 @@
     <value>288, 22</value>
   </data>
   <data name="stopChannelsToolStripMenuItem.Text" xml:space="preserve">
-    <value>チャネルの停止</value>
+    <value>ライブイベントの停止</value>
   </data>
   <data name="resetChannelsToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -3201,7 +3201,7 @@
     <value>288, 22</value>
   </data>
   <data name="resetChannelsToolStripMenuItem.Text" xml:space="preserve">
-    <value>チャネルのリセット</value>
+    <value>ライブイベントのリセット</value>
   </data>
   <data name="deleteChannelsToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -3215,7 +3215,7 @@
     <value>288, 22</value>
   </data>
   <data name="deleteChannelsToolStripMenuItem.Text" xml:space="preserve">
-    <value>チャネルの削除...</value>
+    <value>ライブイベントの削除...</value>
   </data>
   <data name="inputURLToolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
     <value>180, 22</value>
@@ -3371,7 +3371,7 @@
     <value>88, 20</value>
   </data>
   <data name="liveChannelToolStripMenuItem.Text" xml:space="preserve">
-    <value>ライブチャネル</value>
+    <value>ライブイベント</value>
   </data>
   <data name="displayOriginInformationToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/AMSExplorer/Mainform.ja.resx
+++ b/AMSExplorer/Mainform.ja.resx
@@ -1352,7 +1352,7 @@
     <value>256, 22</value>
   </data>
   <data name="ContextMenuItemProgramDisplayInformation.Text" xml:space="preserve">
-    <value>プログラムの情報表示と設定...</value>
+    <value>ライブ出力の情報表示と設定...</value>
   </data>
   <data name="ContextMenuItemProgramDisplayRelatedAssetInformation.Size" type="System.Drawing.Size, System.Drawing">
     <value>256, 22</value>
@@ -1371,13 +1371,13 @@
     <value>256, 22</value>
   </data>
   <data name="createProgramToolStripMenuItem.Text" xml:space="preserve">
-    <value>プログラムの作成...</value>
+    <value>ライブ出力の作成...</value>
   </data>
   <data name="recreateProgramToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>256, 22</value>
   </data>
   <data name="recreateProgramToolStripMenuItem.Text" xml:space="preserve">
-    <value>プログラムのリセット</value>
+    <value>ライブ出力のリセット</value>
   </data>
   <data name="ContextMenuItemProgramStart.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -1393,7 +1393,7 @@
     <value>256, 22</value>
   </data>
   <data name="ContextMenuItemProgramStart.Text" xml:space="preserve">
-    <value>プログラムの開始</value>
+    <value>ライブ出力の開始</value>
   </data>
   <data name="ContextMenuItemProgramStop.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -1406,13 +1406,13 @@
     <value>256, 22</value>
   </data>
   <data name="ContextMenuItemProgramStop.Text" xml:space="preserve">
-    <value>プログラムの停止</value>
+    <value>ライブ出力の停止</value>
   </data>
   <data name="cloneToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>256, 22</value>
   </data>
   <data name="cloneToolStripMenuItem.Text" xml:space="preserve">
-    <value>他のアカウントのプログラムの複製...</value>
+    <value>他のアカウントのライブ出力の複製...</value>
   </data>
   <data name="ContextMenuItemProgramDelete.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -1426,7 +1426,7 @@
     <value>256, 22</value>
   </data>
   <data name="ContextMenuItemProgramDelete.Text" xml:space="preserve">
-    <value>プログラムの削除...</value>
+    <value>ライブ出力の削除...</value>
   </data>
   <data name="toolStripSeparator16.Size" type="System.Drawing.Size, System.Drawing">
     <value>253, 6</value>
@@ -1507,7 +1507,7 @@
     <value>256, 22</value>
   </data>
   <data name="subclipProgramsToolStripMenuItem.Text" xml:space="preserve">
-    <value>プログラムのサブクリッピング...</value>
+    <value>ライブ出力のサブクリッピング...</value>
   </data>
   <data name="withAzureMediaPlayerToolStripMenuItem2.Size" type="System.Drawing.Size, System.Drawing">
     <value>226, 22</value>
@@ -1535,7 +1535,7 @@
     <value>256, 22</value>
   </data>
   <data name="ContextMenuItemProgramPlayback.Text" xml:space="preserve">
-    <value>プログラムの再生</value>
+    <value>ライブ出力の再生</value>
   </data>
   <data name="contextMenuStripPrograms.Size" type="System.Drawing.Size, System.Drawing">
     <value>257, 330</value>
@@ -1550,7 +1550,7 @@
     <value>61, 13</value>
   </data>
   <data name="labelPrograms.Text" xml:space="preserve">
-    <value>プログラム</value>
+    <value>ライブ出力</value>
   </data>
   <data name="labelPrograms.ToolTip" xml:space="preserve">
     <value />
@@ -1583,7 +1583,7 @@
     <value />
   </data>
   <data name="textBoxSearchNameProgram.ToolTip" xml:space="preserve">
-    <value>プログラム名/プログラム ID/アセットID で検索</value>
+    <value>ライブ出力名/ライブ出力 ID/アセットID で検索</value>
   </data>
   <data name="label14.Location" type="System.Drawing.Point, System.Drawing">
     <value>745, 181</value>
@@ -3285,7 +3285,7 @@
     <value>288, 22</value>
   </data>
   <data name="displayProgramInformationToolStripMenuItem.Text" xml:space="preserve">
-    <value>プログラムの情報表示と設定...</value>
+    <value>ライブ出力の情報表示と設定...</value>
   </data>
   <data name="ProgramDisplayRelatedAssetInformationToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>288, 22</value>
@@ -3304,13 +3304,13 @@
     <value>288, 22</value>
   </data>
   <data name="createProgramToolStripMenuItem1.Text" xml:space="preserve">
-    <value>プログラムの作成...</value>
+    <value>ライブ出力の作成...</value>
   </data>
   <data name="recreateProgramsToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>288, 22</value>
   </data>
   <data name="recreateProgramsToolStripMenuItem.Text" xml:space="preserve">
-    <value>プログラムのリセット</value>
+    <value>ライブ出力のリセット</value>
   </data>
   <data name="startProgramsToolStripMenuItem1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -3326,7 +3326,7 @@
     <value>288, 22</value>
   </data>
   <data name="startProgramsToolStripMenuItem1.Text" xml:space="preserve">
-    <value>プログラムの開始</value>
+    <value>ライブ出力の開始</value>
   </data>
   <data name="stopProgramsToolStripMenuItem.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -3339,13 +3339,13 @@
     <value>288, 22</value>
   </data>
   <data name="stopProgramsToolStripMenuItem.Text" xml:space="preserve">
-    <value>プログラムの停止</value>
+    <value>ライブ出力の停止</value>
   </data>
   <data name="toolStripMenuItemCloneProgram.Size" type="System.Drawing.Size, System.Drawing">
     <value>288, 22</value>
   </data>
   <data name="toolStripMenuItemCloneProgram.Text" xml:space="preserve">
-    <value>他のアカウントのプログラムの複製...</value>
+    <value>他のアカウントのライブ出力の複製...</value>
   </data>
   <data name="deleteProgramsToolStripMenuItem1.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
@@ -3359,13 +3359,13 @@
     <value>288, 22</value>
   </data>
   <data name="deleteProgramsToolStripMenuItem1.Text" xml:space="preserve">
-    <value>プログラムの削除...</value>
+    <value>ライブ出力の削除...</value>
   </data>
   <data name="subclipLiveStreamsarchivesToolStripMenuItem1.Size" type="System.Drawing.Size, System.Drawing">
     <value>288, 22</value>
   </data>
   <data name="subclipLiveStreamsarchivesToolStripMenuItem1.Text" xml:space="preserve">
-    <value>プログラムのサブクリッピング...</value>
+    <value>ライブ出力のサブクリッピング...</value>
   </data>
   <data name="liveChannelToolStripMenuItem.Size" type="System.Drawing.Size, System.Drawing">
     <value>88, 20</value>

--- a/AMSExplorer/Properties/Resources.ja.resx
+++ b/AMSExplorer/Properties/Resources.ja.resx
@@ -226,7 +226,7 @@
     <value>(エラー)</value>
   </data>
   <data name="ChannelInformation_ChannelInformation_Load_MultipleChannelsHaveBeenSelected" xml:space="preserve">
-    <value>(複数のチャネルが選択されています)</value>
+    <value>(複数のライブイベントが選択されています)</value>
   </data>
   <data name="BatchUploadFrame2_BatchUploadFrame2_01File" xml:space="preserve">
     <value>{0} ({1} ファイル)</value>
@@ -247,10 +247,10 @@
     <value>{0} アセットが選択されました</value>
   </data>
   <data name="CopyAsset_CopyAsset_0ChannelSelected" xml:space="preserve">
-    <value>{0} チャネルが選択されました</value>
+    <value>{0} ライブイベントが選択されました</value>
   </data>
   <data name="CopyAsset_CopyAsset_0ChannelsSelected" xml:space="preserve">
-    <value>{0} チャネルが選択されました</value>
+    <value>{0} ライブイベントが選択されました</value>
   </data>
   <data name="CopyAsset_CopyAsset_0ProgramSelected" xml:space="preserve">
     <value>{0} ライブ出力が選択されました</value>
@@ -343,40 +343,40 @@
     <value>証明書が必要です</value>
   </data>
   <data name="ChannelAdSlateControl_HideSlate_Channel0ErrorWhenHiddingSlate" xml:space="preserve">
-    <value>チャネル '{0}' : Error when hidding slate</value>
+    <value>ライブイベント '{0}' : Error when hidding slate</value>
   </data>
   <data name="ChannelAdSlateControl_InsertAd_Channel0ErrorWhenSendingSignal" xml:space="preserve">
-    <value>チャネル '{0}' : Error when sending signal</value>
+    <value>ライブイベント '{0}' : Error when sending signal</value>
   </data>
   <data name="ChannelAdSlateControl_ShowSlate_Channel0ErrorWhenShowingSlate" xml:space="preserve">
-    <value>チャネル '{0}' : Error when showing slate</value>
+    <value>ライブイベント '{0}' : Error when showing slate</value>
   </data>
   <data name="ChannelAdSlateControl_InsertAd_Channel0ErrorWithADDurationInput" xml:space="preserve">
-    <value>チャネル '{0}' : Error with AD duration input</value>
+    <value>ライブイベント '{0}' : Error with AD duration input</value>
   </data>
   <data name="ChannelAdSlateControl_InsertAd_Channel0ErrorWithCueIDInput" xml:space="preserve">
-    <value>チャネル '{0}' : Error with CueID input</value>
+    <value>ライブイベント '{0}' : Error with CueID input</value>
   </data>
   <data name="ChannelAdSlateControl_ShowSlate_Channel0ErrorWithSlateDurationInput" xml:space="preserve">
-    <value>チャネル '{0}' : Error with slate duration input</value>
+    <value>ライブイベント '{0}' : Error with slate duration input</value>
   </data>
   <data name="ChannelAdSlateControl_InsertAd_Channel0SendingADSignal" xml:space="preserve">
-    <value>チャネル '{0}' : sending AD signal</value>
+    <value>ライブイベント '{0}' : sending AD signal</value>
   </data>
   <data name="ChannelAdSlateControl_HideSlate_Channel0SendingHideSlateSignal" xml:space="preserve">
-    <value>チャネル '{0}' : sending hide slate signal</value>
+    <value>ライブイベント '{0}' : sending hide slate signal</value>
   </data>
   <data name="ChannelAdSlateControl_ShowSlate_Channel0SendingShowSlateSignal" xml:space="preserve">
-    <value>チャネル '{0}' : sending show slate signal</value>
+    <value>ライブイベント '{0}' : sending show slate signal</value>
   </data>
   <data name="ChannelRunOnPremisesEncoder_BuildArguments_ChannelIsNotRunning" xml:space="preserve">
-    <value>チャネルは実行されていません</value>
+    <value>ライブイベントは実行されていません</value>
   </data>
   <data name="CreateLiveChannel_checkChannelName_ChannelNameIsNotValid" xml:space="preserve">
-    <value>チャネル名が無効です</value>
+    <value>ライブイベント名が無効です</value>
   </data>
   <data name="LabelChannel" xml:space="preserve">
-    <value>チャネル</value>
+    <value>ライブイベント</value>
   </data>
   <data name="AssetInformation_DoDisplayKeyPropertiesAndAutOptions_Checksum" xml:space="preserve">
     <value>チェックサム</value>
@@ -385,10 +385,10 @@
     <value>クリア キーの値</value>
   </data>
   <data name="CopyAsset_CopyAsset_CloneChannel" xml:space="preserve">
-    <value>チャネルの複製</value>
+    <value>ライブイベントの複製</value>
   </data>
   <data name="CopyAsset_CopyAsset_CloneChannels" xml:space="preserve">
-    <value>チャネルの複製</value>
+    <value>ライブイベントの複製</value>
   </data>
   <data name="CopyAsset_CopyAsset_CloneProgram" xml:space="preserve">
     <value>ライブ出力の複製</value>
@@ -651,7 +651,7 @@
     <value>ジョブ</value>
   </data>
   <data name="TabLive" xml:space="preserve">
-    <value>ライブチャネル</value>
+    <value>ライブイベント</value>
   </data>
   <data name="AssetInformation_DoDelLocator_LocatorDeletion" xml:space="preserve">
     <value>ロケーター削除</value>

--- a/AMSExplorer/Properties/Resources.ja.resx
+++ b/AMSExplorer/Properties/Resources.ja.resx
@@ -253,10 +253,10 @@
     <value>{0} チャネルが選択されました</value>
   </data>
   <data name="CopyAsset_CopyAsset_0ProgramSelected" xml:space="preserve">
-    <value>{0} プログラムが選択されました</value>
+    <value>{0} ライブ出力が選択されました</value>
   </data>
   <data name="CopyAsset_CopyAsset_0ProgramsSelected" xml:space="preserve">
-    <value>{0} プログラムが選択されました</value>
+    <value>{0} ライブ出力が選択されました</value>
   </data>
   <data name="DynamicEncryption_AddTokenRestrictedAuthorizationPolicyAES_0TokenAuthorizationPolicy" xml:space="preserve">
     <value>{0} 承認ポリシー</value>
@@ -391,10 +391,10 @@
     <value>チャネルの複製</value>
   </data>
   <data name="CopyAsset_CopyAsset_CloneProgram" xml:space="preserve">
-    <value>プログラムの複製</value>
+    <value>ライブ出力の複製</value>
   </data>
   <data name="CopyAsset_CopyAsset_ClonePrograms" xml:space="preserve">
-    <value>プログラムの複製</value>
+    <value>ライブ出力の複製</value>
   </data>
   <data name="EditorXMLJSON_EditorXMLJSON_Close" xml:space="preserve">
     <value>閉じる</value>

--- a/AMSExplorer/options.ja.resx
+++ b/AMSExplorer/options.ja.resx
@@ -239,7 +239,7 @@
     <value>81, 19</value>
   </data>
   <data name="checkBoxDisplayChannelID.Text" xml:space="preserve">
-    <value>チャネル ID</value>
+    <value>ライブイベント ID</value>
   </data>
   <data name="checkBoxDisplayChannelID.ToolTip" xml:space="preserve">
     <value />

--- a/AMSExplorer/options.ja.resx
+++ b/AMSExplorer/options.ja.resx
@@ -230,7 +230,7 @@
     <value>89, 19</value>
   </data>
   <data name="checkBoxDisplayProgramID.Text" xml:space="preserve">
-    <value>プログラム ID</value>
+    <value>ライブ出力 ID</value>
   </data>
   <data name="checkBoxDisplayProgramID.ToolTip" xml:space="preserve">
     <value />


### PR DESCRIPTION
## Purpose

<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Japanese correction for AMSv3 
    * "チャネル" (Channel) to "ライブイベント" (Live Event)
    * "プログラム" (Program) to "ライブ出力" (Live Output)


### This change concerns: (mark with an `x`)
```
- [ ] AMSE v4.x (for AMS v2) in 'AMSv2' branch
- [x] AMSE v5.x (for AMS v3) in 'master' branch
- [ ] Other
```

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] User Interface
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* I just replaced the existing words in Japanese resx files automatically. So there are some legacy values. I've ignored them on this pull request.

## Other Information
<!-- Add any other helpful information that may be needed here. -->