### PR TITLE
Fix WidevineTemplate value to serialize with snake case.

### DIFF
--- a/AMSExplorer/Forms-DynamicEncryption/WidevineConfiguration.cs
+++ b/AMSExplorer/Forms-DynamicEncryption/WidevineConfiguration.cs
@@ -1,32 +1,48 @@
-﻿namespace AMSExplorer
+﻿using Newtonsoft.Json;
+
+namespace AMSExplorer
 {
     // <WidevineConfigurationClasses>
     public class PolicyOverrides
     {
+        [JsonProperty("can_play")]
         public bool CanPlay { get; set; }
+        [JsonProperty("can_persist")]
         public bool CanPersist { get; set; }
+        [JsonProperty("can_renew")]
         public bool CanRenew { get; set; }
+        [JsonProperty("rental_duration_seconds")]
         public int RentalDurationSeconds { get; set; }    //Indicates the time window while playback is permitted. A value of 0 indicates that there is no limit to the duration. Default is 0.
+        [JsonProperty("playback_duration_seconds")]
         public int PlaybackDurationSeconds { get; set; }  //The viewing window of time after playback starts within the license duration. A value of 0 indicates that there is no limit to the duration. Default is 0.
+        [JsonProperty("license_duration_seconds")]
         public int LicenseDurationSeconds { get; set; }   //Indicates the time window for this specific license. A value of 0 indicates that there is no limit to the duration. Default is 0.
     }
 
     public class ContentKeySpec
     {
+        [JsonProperty("track_type")]
         public string TrackType { get; set; }
+        [JsonProperty("security_level")]
         public int SecurityLevel { get; set; }
+        [JsonProperty("required_output_protection")]
         public OutputProtection RequiredOutputProtection { get; set; }
+
     }
 
     public class OutputProtection
     {
+        [JsonProperty("hdcp")]
         public string HDCP { get; set; }
     }
 
     public class WidevineTemplate
     {
+        [JsonProperty("allowed_track_types")]
         public string AllowedTrackTypes { get; set; }
+        [JsonProperty("content_key_specs")] 
         public ContentKeySpec[] ContentKeySpecs { get; set; }
+        [JsonProperty("policy_overrides")]
         public PolicyOverrides PolicyOverrides { get; set; }
     }
     // </WidevineConfigurationClasses>


### PR DESCRIPTION
See more info here: https://docs.microsoft.com/en-us/azure/media-services/latest/drm-widevine-license-template-concept

## Purpose
* The value of the property, "WidevineTemplate" in Microsoft.Azure.Management.Media.Models.ContentKeyPolicyWidevineConfiguration should be JSON string with **snake case**. (https://docs.microsoft.com/en-us/azure/media-services/latest/drm-widevine-license-template-concept) 
* However, the example value of advanced license for Widevine is serialized with pascal case in Azure Media Services Explorer, 
* I can write down snake case manually.

### This change concerns: (mark with an `x`)
```
- [ ] AMSE v4.x (for AMS v2) in 'AMSv2' branch
- [x ] AMSE v5.x (for AMS v3) in 'main' branch
- [ ] Other
```

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x] Bugfix
[ ] Feature
[ ] User Interface
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
1. Go to the page "DRM_WidevineLicence.cs" by publishing locator with Widevine.
2. Select "Advanced license"
3. You can see JSON with snake case instead of pascal case.

```
{
  "allowed_track_types": "SD_HD",
  "content_key_specs": [
    {
      "track_type": "SD",
      "security_level": 1,
      "required_output_protection": {
        "hdcp": "HDCP_NONE"
      }
    }
  ],
  "policy_overrides": {
    "can_play": true,
    "can_persist": true,
    "can_renew": false,
    "rental_duration_seconds": 2592000,
    "playback_duration_seconds": 10800,
    "license_duration_seconds": 604800
  }
}
```

If you want to check more,  use Desktop Browser with Non-HDCP display like VGA. With the configuration No.1, HDCP_V1 restriction is not effective and you can play video with  VGA connection in spite of HDCP_V1 restriction. However, If you set the configuration No.2, playback with VGA will be blocked. It means that the value of WidevineTemplate should be JSON string with snake case. 

No. 1: Pascal Case
```
{
  "AllowedTrackTypes": "SD_HD",
  "ContentKeySpecs": [
    {
      "TrackType": "SD",
      "SecurityLevel": 1,
      "RequiredOutputProtection": {
        "HDCP": "HDCP_V1"
      }
    }
  ],
  "PolicyOverrides": {
    "CanPlay": true,
    "CanPersist": true,
    "CanRenew": false,
    "RentalDurationSeconds": 2592000,
    "PlaybackDurationSeconds": 10800,
    "LicenseDurationSeconds": 604800
  }
}
```

No. 2: Snake Case
```
{
  "allowed_track_types": "SD_HD",
  "content_key_specs": [
    {
      "track_type": "SD",
      "security_level": 1,
      "required_output_protection": {
        "hdcp": "HDCP_V1"
      }
    }
  ],
  "policy_overrides": {
    "can_play": true,
    "can_persist": true,
    "can_renew": false,
    "rental_duration_seconds": 2592000,
    "playback_duration_seconds": 10800,
    "license_duration_seconds": 604800
  }
}
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
